### PR TITLE
Add branch flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ var (
 	queryFileFlag       string
 	querySuiteFileFlag  string
 	additionalPacksFlag string
-	branchFlag string
+	actionBranchFlag 	string
 )
 var rootCmd = &cobra.Command{
 	Use:   "gh-mrva",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var (
 	queryFileFlag       string
 	querySuiteFileFlag  string
 	additionalPacksFlag string
+	branchFlag string
 )
 var rootCmd = &cobra.Command{
 	Use:   "gh-mrva",

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -24,7 +24,7 @@ var (
 	sessionName     string
 	queryFile       string
 	querySuiteFile  string
-	branch        	string
+	actionBranch    string
 )
 var submitCmd = &cobra.Command{
 	Use:   "submit",
@@ -46,7 +46,7 @@ func init() {
 	submitCmd.Flags().StringVarP(&listFlag, "list", "i", "", "Name of repo list")
 	submitCmd.Flags().StringVarP(&codeqlPathFlag, "codeql-path", "p", "", "Path to CodeQL distribution (overrides config file)")
 	submitCmd.Flags().StringVarP(&additionalPacksFlag, "additional-packs", "a", "", "Additional Packs")
-	submitCmd.Flags().StringVarP(&branchFlag, "branch", "b", "main", "github/codeql-variant-analysis-action branch to use")
+	submitCmd.Flags().StringVarP(&actionBranchFlag, "action-branch", "b", "main", "github/codeql-variant-analysis-action branch to use")
 	submitCmd.MarkFlagRequired("session")
 	submitCmd.MarkFlagRequired("language")
 	submitCmd.MarkFlagsMutuallyExclusive("query", "query-suite")
@@ -91,8 +91,8 @@ func submitQuery() {
 	if querySuiteFileFlag != "" {
 		querySuiteFile = querySuiteFileFlag
 	}
-	if branchFlag != "" {
-		branch = branchFlag
+	if actionBranchFlag != "" {
+		actionBranch = actionBranchFlag
 	}
 
 	if codeqlPath != "" {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -24,6 +24,7 @@ var (
 	sessionName     string
 	queryFile       string
 	querySuiteFile  string
+	branch        	string
 )
 var submitCmd = &cobra.Command{
 	Use:   "submit",
@@ -45,6 +46,7 @@ func init() {
 	submitCmd.Flags().StringVarP(&listFlag, "list", "i", "", "Name of repo list")
 	submitCmd.Flags().StringVarP(&codeqlPathFlag, "codeql-path", "p", "", "Path to CodeQL distribution (overrides config file)")
 	submitCmd.Flags().StringVarP(&additionalPacksFlag, "additional-packs", "a", "", "Additional Packs")
+	submitCmd.Flags().StringVarP(&branchFlag, "branch", "b", "main", "github/codeql-variant-analysis-action branch to use")
 	submitCmd.MarkFlagRequired("session")
 	submitCmd.MarkFlagRequired("language")
 	submitCmd.MarkFlagsMutuallyExclusive("query", "query-suite")
@@ -88,6 +90,9 @@ func submitQuery() {
 	}
 	if querySuiteFileFlag != "" {
 		querySuiteFile = querySuiteFileFlag
+	}
+	if branchFlag != "" {
+		branch = branchFlag
 	}
 
 	if codeqlPath != "" {
@@ -152,7 +157,7 @@ func submitQuery() {
 			chunks = append(chunks, repositories[i:end])
 		}
 		for _, chunk := range chunks {
-			id, err := utils.SubmitRun(controller, language, chunk, encodedBundle)
+			id, err := utils.SubmitRun(controller, language, chunk, encodedBundle, branch)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -172,7 +172,7 @@ func SaveSession(name string, controller string, runs []models.Run, language str
 	return nil
 }
 
-func SubmitRun(controller string, language string, repoChunk []string, bundle string, branch string) (int, error) {
+func SubmitRun(controller string, language string, repoChunk []string, bundle string, actionBranch string) (int, error) {
 	opts := api.ClientOptions{
 		Headers: map[string]string{"Accept": "application/vnd.github.v3+json"},
 	}
@@ -189,7 +189,7 @@ func SubmitRun(controller string, language string, repoChunk []string, bundle st
 		Repositories: repoChunk,
 		Language:     language,
 		Pack:         bundle,
-		Ref:          branch,
+		Ref:          actionBranch,
 	}
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(body)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -172,7 +172,7 @@ func SaveSession(name string, controller string, runs []models.Run, language str
 	return nil
 }
 
-func SubmitRun(controller string, language string, repoChunk []string, bundle string) (int, error) {
+func SubmitRun(controller string, language string, repoChunk []string, bundle string, branch string) (int, error) {
 	opts := api.ClientOptions{
 		Headers: map[string]string{"Accept": "application/vnd.github.v3+json"},
 	}
@@ -189,7 +189,7 @@ func SubmitRun(controller string, language string, repoChunk []string, bundle st
 		Repositories: repoChunk,
 		Language:     language,
 		Pack:         bundle,
-		Ref:          "main",
+		Ref:          branch,
 	}
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(body)


### PR DESCRIPTION
This pull request primarily introduces the `actionBranch` flag to the `gh-mrva` command-line tool. The flag is added to the root and submit command structures, and is used to specify the branch of the `github/codeql-variant-analysis-action` to use when submitting a query. The default value for this flag is "main". 

Here are the key changes:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR49): Added `actionBranchFlag` to the root command's flag structure.
* [`cmd/submit.go`](diffhunk://#diff-f52729ee586405b4173291bbf009f1e69ff61c2aa42149ae5ec1fc81a805b1fcR27): Added `actionBranch` to the submit command's flag structure.
* [`cmd/submit.go`](diffhunk://#diff-f52729ee586405b4173291bbf009f1e69ff61c2aa42149ae5ec1fc81a805b1fcR49): Included the `actionBranchFlag` in the `init()` function for the submit command, with a default value of "main".
* [`cmd/submit.go`](diffhunk://#diff-f52729ee586405b4173291bbf009f1e69ff61c2aa42149ae5ec1fc81a805b1fcR94-R96): Updated the `submitQuery()` function to set `actionBranch` to the value of `actionBranchFlag` if it is not an empty string.
* `cmd/submit.go` & `utils/utils.go`: Modified the `SubmitRun()` function call in `submitQuery()` and the function definition in `utils.go` to include `actionBranch` as a parameter. This parameter is used to specify the branch reference in the `SubmitRun()` function. [[1]](diffhunk://#diff-f52729ee586405b4173291bbf009f1e69ff61c2aa42149ae5ec1fc81a805b1fcL155-R160) [[2]](diffhunk://#diff-0df82f8689d3e8d881be0653ab4e9f8221c5835ec95a14930d11669e9c7f07efL175-R175) [[3]](diffhunk://#diff-0df82f8689d3e8d881be0653ab4e9f8221c5835ec95a14930d11669e9c7f07efL192-R192)